### PR TITLE
Configurable label separator

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,6 @@
   :source-paths ["src"]
   :dependencies [[org.clojure/clojure "1.6.0" :scope "provided"]
                  [org.clojure/clojurescript "0.0-2850" :scope "provided"]
-
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [prismatic/schema "0.3.3"]
                  [prismatic/plumbing "0.3.5"]
@@ -16,4 +15,24 @@
                  [com.andrewmcveigh/cljs-time "0.3.0"]
                  [cljsjs/moment "2.6.0-3"]
                  [cljsjs/pikaday "1.2.0-2"]]
-  :plugins [[lein-pprint "1.1.2"]])
+  :plugins [[lein-pprint "1.1.2"]]
+
+  :cljsbuild
+  {:builds {:test {:source-paths ["src" "test"]
+                   :notify-command ["phantomjs" :cljs.test/runner 
+                                    "test/phantomjs-shims.js" 
+                                    "target/testable.js"]
+                   :compiler {:output-to  "target/testable.js"
+                              :output-dir "target/cljsbuild-test"
+                              :source-map "target/cljsbuild-test.js.map"
+                              :optimizations :whitespace
+                              :pretty-print  true}}}
+   :test-commands {"test" ["phantomjs" :runner 
+                           "test/phantomjs-shims.js" 
+                           "target/testable.js"]}}
+
+  :profiles
+  {:dev
+   {:source-paths ["dev-src/clj"]
+    :plugins [[lein-cljsbuild "1.0.4"]
+              [com.cemerick/clojurescript.test "0.3.3"]]}})

--- a/src/lomakkeet/fields.cljs
+++ b/src/lomakkeet/fields.cljs
@@ -61,8 +61,8 @@
 (defcomponent default-form-group
   [{:keys [error] :as input-state}
    owner
-   {:keys [input label size help-text]
-    :or {size 6}
+   {:keys [input label label-separator size help-text]
+    :or {size 6 label-separator ":"}
     :as opts}]
   (render-state [_ s]
     (html
@@ -70,7 +70,7 @@
        {:class (cond-> []
                  (and error) (conj "has-error")
                  size (conj (str "col-md-" size)))}
-       [:label label ":"]
+       [:label label label-separator]
        (om/build input input-state {:opts opts :state s})
        (if help-text
          [:span.help-block help-text])
@@ -240,8 +240,8 @@
    {:keys [actions render-fn form form-validation-fn after-change]
     :as opts}]
   (init-state [_]
-    ; (js/console.log (str @state))
-    ; (js/console.log (str (s/check FormState form-state)))
+;;     (js/console.log (str "STATE:" @form-state))
+;;     (js/console.log (str "CHECK:" (s/check FormState form-state)))
     (assert (nil? (s/check FormState form-state)))
     (-> {:ch (chan)
          :form-group default-form-group

--- a/test/lomakkeet/autocomplete-test.cljs
+++ b/test/lomakkeet/autocomplete-test.cljs
@@ -1,9 +1,7 @@
 (ns lomakkeet.autocomplete-test
-  (:require [cljs.test :as test :refer-macros [deftest testing is]]
-            [lomakkeet.autocomplete :as [ac]]))
+  (:require [cemerick.cljs.test :as test :refer-macros [deftest testing is]]
+            [lomakkeet.autocomplete :as ac]))
 
 (deftest highlight-match-test
-  (is (= (highlight-match "FI: Finland" ["fi"])
-         [:span [:span.highlight "FI"] ": Finland"])))
-
-(test/run-tests)
+  (is (= (ac/highlight-match [:span "Finland"] ["fi"])
+         [:span "" [:span.highlight "Fi"] "nland"])))

--- a/test/lomakkeet/common-test.cljs
+++ b/test/lomakkeet/common-test.cljs
@@ -1,0 +1,15 @@
+(ns lomakkeet.common-test)
+
+(defn container-div []
+  (let [id  (str "container-" (gensym))
+        div (.createElement js/document "div")]
+    (aset div "id" id)
+    [div (str  id)]))
+
+(defn append-container [container]
+  (-> js/document .-body (.appendChild container)))
+
+(defn create-container []
+  (let [[n id] (container-div)]
+    (append-container n)
+    (.getElementById js/document id)))

--- a/test/lomakkeet/forms-tests.cljs
+++ b/test/lomakkeet/forms-tests.cljs
@@ -1,0 +1,57 @@
+(ns lomakkeet.forms-tests
+  (:require [cemerick.cljs.test :refer-macros [deftest testing is done]]
+            [lomakkeet.common-test :as c]
+            [lomakkeet.fields :as f]
+            [sablono.core :refer-macros [html]]
+            [schema.core :as s :include-macros true]
+            [plumbing.core :refer-macros [defnk]]
+            [om.core :as om :include-macros true]
+            [om-tools.dom :as dom :include-macros true]
+            [om-tools.core :refer-macros [defcomponent]]))
+
+(extend-type js/NodeList
+  ISeqable
+  (-seq [array] (array-seq array 0)))
+
+(s/defschema Thingie
+  {:name s/Str})
+
+(def empty-thing
+  {:name "Luke Skywalker"})
+
+(def initial-state
+  (f/->form-state empty-thing Thingie))
+
+(def state (atom initial-state))
+
+(declare test-render)
+
+(defn test-render-with-opts [opts more]
+  (test-render (assoc more :opts opts)))
+
+(defnk test-render
+  [opts form-state form ch value]
+  (html
+    (f/input form "name" [:name] opts)))
+
+(defn test-view
+  [opts state owner]
+  (reify
+    om/IRender
+    (render [this]
+      (om/build
+        f/form state
+        {:opts {:render-fn (partial test-render-with-opts opts)}}))))
+
+(defn label
+  [cnt]
+  (let [elems (.querySelectorAll cnt "label span")]
+    (reduce str (map #(.-innerText %) elems))))
+
+(deftest test-label-separator
+  (let [cnt (c/create-container)]
+    (om/root (partial test-view {}) state {:target cnt})
+    (is (= "name:" (label cnt))))
+  (let [cnt (c/create-container)]
+    (om/root (partial test-view {:label-separator ""}) state {:target cnt})
+    (is (= "name" (label cnt)))))

--- a/test/phantomjs-shims.js
+++ b/test/phantomjs-shims.js
@@ -1,0 +1,35 @@
+(function() {
+
+var Ap = Array.prototype;
+var slice = Ap.slice;
+var Fp = Function.prototype;
+
+if (!Fp.bind) {
+  // PhantomJS doesn't support Function.prototype.bind natively, so
+  // polyfill it whenever this module is required.
+  Fp.bind = function(context) {
+    var func = this;
+    var args = slice.call(arguments, 1);
+
+    function bound() {
+      var invokedAsConstructor = func.prototype && (this instanceof func);
+      return func.apply(
+        // Ignore the context parameter when invoking the bound function
+        // as a constructor. Note that this includes not only constructor
+        // invocations using the new keyword but also calls to base class
+        // constructors such as BaseClass.call(this, ...) or super(...).
+        !invokedAsConstructor && context || this,
+        args.concat(slice.call(arguments))
+      );
+    }
+
+    // The bound function must share the .prototype of the unbound
+    // function so that any object created by one constructor will count
+    // as an instance of both constructors.
+    bound.prototype = func.prototype;
+
+    return bound;
+  };
+}
+
+})();

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,89 @@
+<html lang="en">
+  <head>
+    <title>Unit Tests</title>
+
+    <!-- Use a monspace font and a dark theme -->
+    <!-- Colour Palet from http://clrs.cc/    -->
+    <style>
+        body {
+            font-family: Courier, "Courier New", monospace;
+            font-size: 11;
+            background-color: #111;
+            color: #eee;
+            margin: 0.25in 0.25in 0.25in 0.25in;
+        }
+        h2 {
+            font-size: 24;
+        }
+        .red {
+            color: #FF4136;
+        }
+        .green {
+            color: #2ECC40;
+        }
+        .orange {
+            color: #FF851B;
+        }
+        .blue {
+            color: #0074D9;
+        }
+    </style>
+  </head>
+
+  <body>
+    <h2>Unit Tests</h2>
+    <div id="output-goes-here"></div>
+
+    <script src="../target/testable.js"      type="text/javascript"></script>
+
+    <script>
+
+        // --------------------------------------------------------------------
+        // Output
+        var outputDiv = document.getElementById("output-goes-here")
+
+        function testPrintLn(line) {
+            line = line.replace(/\n/g, "");
+            if (line == "")
+               return;
+
+            // First, to the console
+            console.log(line);
+
+            // Second, into the HTML
+            var span = document.createElement("span");
+            outputDiv.appendChild(span);
+
+            // look for colour markers
+            if (-1 != line.indexOf('ERROR')) {
+                span.className = "orange"
+            }
+            if (-1 != line.indexOf('FAIL')) {
+                span.className = "red"
+            }
+            if (-1 != line.indexOf('Testing complete')) {
+                span.className = "green"
+            }
+
+            // replace leading blanks with &nbsp; so text lines up
+            var numLeadingBlanks = line.match(/^\s*/)[0].length;
+            var leadingNBSP = Array(numLeadingBlanks).join("&nbsp;")
+
+            span.innerHTML = leadingNBSP + line + "<br>";
+        }
+
+        // --------------------------------------------------------------------
+        // Run Tests
+        //
+        function run_tests() {
+            cemerick.cljs.test.set_print_fn_BANG_(testPrintLn);
+            var results = cemerick.cljs.test.run_all_tests();
+        }
+
+
+        // Don't run any tests till this page is fully loaded.
+        // Remember there'll be lots of async <script> added by the loop above.
+        window.addEventListener('load', run_tests);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Added `:label-separator` option to allow omit `:`  between input label and input itself.

Also added basic tests for forms and fixed autocomplete tests.
